### PR TITLE
Fix issue with lerna bootstrap

### DIFF
--- a/packages/resolve-scripts/bin/resolve-scripts.js
+++ b/packages/resolve-scripts/bin/resolve-scripts.js
@@ -3,22 +3,22 @@
 const taskName = process.argv[2];
 switch (taskName) {
     case 'dev':
-        require('../scripts/runDev');
+        require('../dist/scripts/runDev');
         break;
     case 'build':
-        require('../scripts/runBuild');
+        require('../dist/scripts/runBuild');
         break;
     case 'start':
-        require('../scripts/runStart');
+        require('../dist/scripts/runStart');
         break;
     case 'link':
-        require('../scripts/runLint');
+        require('../dist/scripts/runLint');
         break;
     case 'test':
-        require('../scripts/runTest');
+        require('../dist/scripts/runTest');
         break;
     case 'test:e2e':
-        require('../scripts/runTestE2e');
+        require('../dist/scripts/runTestE2e');
         break;
     default:
         // eslint-disable-next-line no-console

--- a/packages/resolve-scripts/package.json
+++ b/packages/resolve-scripts/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/reimagined/resolve/issues"
   },
   "bin": {
-    "resolve-scripts": "./dist/bin/resolve-scripts.js"
+    "resolve-scripts": "./bin/resolve-scripts.js"
   },
   "scripts": {
     "prepublish": "babel --out-dir ./dist ./src"
@@ -18,12 +18,7 @@
   },
   "author": "reimagined team",
   "license": "MIT",
-  "keywords": [
-    "cqrs",
-    "eventsourcing",
-    "es",
-    "ddd"
-  ],
+  "keywords": ["cqrs", "eventsourcing", "es", "ddd"],
   "homepage": "https://github.com/reimagined/resolve/tree/master/packages/resolve-redux#readme",
   "dependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
It is a fix for #160. The problem was in copying binary files during npm installation. At first, "lerna bootstrap" runs 'npm install' in all modules. After that,  it creates a symlink for dependent packages and on this step we have a problem, because 'npm run prepublish' haven't been called yet but npm tries to copy the binary file to the _bin folder of node_modules.