### PR TITLE
Add default params for saga middlewares

### DIFF
--- a/packages/resolve-redux/README.md
+++ b/packages/resolve-redux/README.md
@@ -22,7 +22,7 @@ This package contains utils to integrate reSolve with [Redux](http://redux.js.or
 ## 🛠 Utils
 * ### `sendCommandMiddleware`   
 	It is a Redux middleware used to send a command to the server side. It takes an object with the following field:
-	* `sendCommand` - a function used to send a command to the server side. It takes `command` and returns the `Promise` object that will be resolved when the command is handled by the server. If a function is not specified, command will be posted to `/api/commands` url.
+	* `sendCommand` - a function used to send a command to the server side. It takes `command` and returns the `Promise` object that will be resolved when the command is handled by the server. If the function is not specified, the command will be posted to `/api/commands` url.
 
 	**Example:**  
 	```js
@@ -42,7 +42,7 @@ This package contains utils to integrate reSolve with [Redux](http://redux.js.or
 
 * ### `setSubscriptionMiddleware`  
 	It is a Redux middleware used to get events from `bus`.  It is used with [`actions.setSubscription`](#setsubscription) to subscribe to required event types. It takes an object with the following field:
-	* `rootDirPath` - URL where socket is placed. If URL is not specified, the `process.env.ROOT_DIR` value or an empty string will be used. The `process.env.ROOT_DIR` is [passed by resolve-scripts](https://github.com/reimagined/resolve/tree/feature/saga-default-params/packages/resolve-scripts/src/template#environment-variables-to-change-url).
+	* `rootDirPath` - URL where socket is placed. If URL is not specified, the `process.env.ROOT_DIR` value or an empty string will be used. The `process.env.ROOT_DIR` value is [passed by resolve-scripts](https://github.com/reimagined/resolve/tree/feature/saga-default-params/packages/resolve-scripts/src/template#environment-variables-to-change-url).
 
 	**Example:**  
 	```js

--- a/packages/resolve-redux/README.md
+++ b/packages/resolve-redux/README.md
@@ -42,7 +42,7 @@ This package contains utils to integrate reSolve with [Redux](http://redux.js.or
 
 * ### `setSubscriptionMiddleware`  
 	It is a Redux middleware used to get events from `bus`.  It is used with [`actions.setSubscription`](#setsubscription) to subscribe to required event types. It takes an object with the following field:
-	* `rootDirPath` - URL where socket is placed. If URL is not specified, the `process.env.ROOT_DIR` value or an empty string will be used.
+	* `rootDirPath` - URL where socket is placed. If URL is not specified, the `process.env.ROOT_DIR` value or an empty string will be used. The `process.env.ROOT_DIR` is [passed by resolve-scripts](https://github.com/reimagined/resolve/tree/master/packages/resolve-redux#setsubscriptionmiddleware).
 
 	**Example:**  
 	```js
@@ -53,7 +53,7 @@ This package contains utils to integrate reSolve with [Redux](http://redux.js.or
 
 	const middleware = [
 	  setSubscriptionMiddleware({
-	    rootDirPath: process.env.ROOT_DIR
+	    rootDirPath: '/my-path'
 	  })
 	]
 
@@ -241,8 +241,8 @@ const readModel = {
 const reducer = createReducer(readModel, (state, action) => {
   switch (action.type) {
     case 'SEND_COMMAND_TODO_UPDATE_TEXT': {
-      // Optimistic update
-      if(!action.error) {
+      if(!action.command.error) {
+        // Optimistic update
         return state.map(item => {
           if(item.id === event.aggregateId) {
             return {
@@ -253,7 +253,7 @@ const reducer = createReducer(readModel, (state, action) => {
           }
         })
       } else {
-      // Revert optimistic update
+        // Revert optimistic update
         return state.map(item => {
           if(item.id === event.aggregateId) {
             return {

--- a/packages/resolve-redux/README.md
+++ b/packages/resolve-redux/README.md
@@ -42,7 +42,7 @@ This package contains utils to integrate reSolve with [Redux](http://redux.js.or
 
 * ### `setSubscriptionMiddleware`  
 	It is a Redux middleware used to get events from `bus`.  It is used with [`actions.setSubscription`](#setsubscription) to subscribe to required event types. It takes an object with the following field:
-	* `rootDirPath` - URL where socket is placed. If URL is not specified, the `process.env.ROOT_DIR` value or an empty string will be used. The `process.env.ROOT_DIR` is [passed by resolve-scripts](https://github.com/reimagined/resolve/tree/master/packages/resolve-redux#setsubscriptionmiddleware).
+	* `rootDirPath` - URL where socket is placed. If URL is not specified, the `process.env.ROOT_DIR` value or an empty string will be used. The `process.env.ROOT_DIR` is [passed by resolve-scripts](https://github.com/reimagined/resolve/tree/feature/saga-default-params/packages/resolve-scripts/src/template#environment-variables-to-change-url).
 
 	**Example:**  
 	```js

--- a/packages/resolve-redux/README.md
+++ b/packages/resolve-redux/README.md
@@ -22,7 +22,7 @@ This package contains utils to integrate reSolve with [Redux](http://redux.js.or
 ## 🛠 Utils
 * ### `sendCommandMiddleware`   
 	It is a Redux middleware used to send a command to the server side. It takes an object with the following field:
-	* `sendCommand` - a function used to send a command to the server side. It takes `command` and returns the `Promise` object that will be resolved when the command is handled by the server.
+	* `sendCommand` - a function used to send a command to the server side. It takes `command` and returns the `Promise` object that will be resolved when the command is handled by the server. If a function is not specified, command will be posted to `/api/commands` url.
 
 	**Example:**  
 	```js
@@ -42,7 +42,7 @@ This package contains utils to integrate reSolve with [Redux](http://redux.js.or
 
 * ### `setSubscriptionMiddleware`  
 	It is a Redux middleware used to get events from `bus`.  It is used with [`actions.setSubscription`](#setsubscription) to subscribe to required event types. It takes an object with the following field:
-	* `rootDirPath` - URL where socket is placed.
+	* `rootDirPath` - URL where socket is placed. If URL is not specified, the `process.env.ROOT_DIR` value or an empty string will be used.
 
 	**Example:**  
 	```js

--- a/packages/resolve-redux/package-lock.json
+++ b/packages/resolve-redux/package-lock.json
@@ -1,6 +1,8 @@
 {
-  "requires": true,
+  "name": "resolve-redux",
+  "version": "0.0.26",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "after": {
       "version": "0.8.2",
@@ -15,7 +17,8 @@
     "assertion-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
     },
     "backo2": {
       "version": "1.0.2",
@@ -25,7 +28,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
@@ -49,6 +53,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -57,7 +62,8 @@
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
     },
     "callsite": {
       "version": "1.0.0",
@@ -68,6 +74,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
       "requires": {
         "assertion-error": "1.0.2",
         "deep-eql": "0.1.3",
@@ -78,6 +85,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
       "requires": {
         "graceful-readlink": "1.0.1"
       }
@@ -100,12 +108,14 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "debug": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
       "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+      "dev": true,
       "requires": {
         "ms": "0.7.2"
       }
@@ -114,6 +124,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
       "requires": {
         "type-detect": "0.1.1"
       },
@@ -121,14 +132,24 @@
         "type-detect": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
         }
       }
     },
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
     },
     "engine.io-client": {
       "version": "3.1.1",
@@ -179,12 +200,14 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "formatio": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
       "requires": {
         "samsam": "1.2.1"
       }
@@ -192,12 +215,14 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -210,12 +235,14 @@
     "graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
     },
     "growl": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
     },
     "has-binary2": {
       "version": "1.0.2",
@@ -240,7 +267,13 @@
     "has-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "indexof": {
       "version": "0.0.1",
@@ -251,6 +284,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -259,37 +293,58 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      }
     },
     "js-tokens": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc="
+      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
     },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash-es": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc=",
+      "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
       "requires": {
         "lodash._basecopy": "3.0.1",
         "lodash.keys": "3.1.2"
@@ -298,27 +353,32 @@
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
     },
     "lodash._basecreate": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
     },
     "lodash.create": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
       "requires": {
         "lodash._baseassign": "3.2.0",
         "lodash._basecreate": "3.0.3",
@@ -328,17 +388,20 @@
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
       "requires": {
         "lodash._getnative": "3.9.1",
         "lodash.isarguments": "3.1.0",
@@ -348,12 +411,14 @@
     "lolex": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
+      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
       "requires": {
         "js-tokens": "3.0.1"
       }
@@ -361,7 +426,8 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -369,12 +435,14 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -383,6 +451,7 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
         "commander": "2.9.0",
@@ -400,12 +469,23 @@
     "ms": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+      "dev": true
     },
     "native-promise-only": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
     },
     "object-component": {
       "version": "0.0.3",
@@ -416,6 +496,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -447,12 +528,14 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
       "requires": {
         "isarray": "0.0.1"
       }
@@ -461,6 +544,7 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.0.tgz",
       "integrity": "sha512-GHjaOkEQtQnnuLoYPFkRKHIqs1i1tdTlisu/xUHfk2juzCobSy4STxs4Lz5bPkc07Owb6BeGKx/r76c9IVTkOw==",
+      "dev": true,
       "requires": {
         "lodash": "4.17.4",
         "lodash-es": "4.17.4",
@@ -476,17 +560,20 @@
     "samsam": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc="
+      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
+      "dev": true
     },
     "seamless-immutable": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.2.tgz",
-      "integrity": "sha1-yHoeumdnoyRVMR12YArF7d6vu2k="
+      "integrity": "sha1-yHoeumdnoyRVMR12YArF7d6vu2k=",
+      "dev": true
     },
     "sinon": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.5.tgz",
       "integrity": "sha1-mi/A/41SbacW8wlTqixl1RiRf2w=",
+      "dev": true,
       "requires": {
         "diff": "3.2.0",
         "formatio": "1.2.0",
@@ -501,7 +588,8 @@
         "type-detect": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-          "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo="
+          "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+          "dev": true
         }
       }
     },
@@ -575,6 +663,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
       "requires": {
         "has-flag": "1.0.0"
       }
@@ -582,12 +671,14 @@
     "symbol-observable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
+      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+      "dev": true
     },
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "to-array": {
       "version": "0.1.4",
@@ -597,7 +688,8 @@
     "type-detect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
     },
     "ultron": {
       "version": "1.1.0",
@@ -607,12 +699,19 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "ws": {
       "version": "2.3.1",

--- a/packages/resolve-redux/package-lock.json
+++ b/packages/resolve-redux/package-lock.json
@@ -1,736 +1,646 @@
 {
-  "name": "resolve-redux",
-  "version": "0.0.26",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
-    },
-    "arraybuffer.slice": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
-    },
-    "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
-      "dev": true
-    },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
-    },
-    "better-assert": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "requires": {
-        "callsite": "1.0.0"
-      }
-    },
-    "blob": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
-    },
-    "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-      "dev": true
-    },
-    "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-    },
-    "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true,
-      "requires": {
-        "assertion-error": "1.0.2",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
-      }
-    },
-    "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": "1.0.1"
-      }
-    },
-    "component-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
-    },
-    "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-    },
-    "component-inherit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "debug": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-      "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-      "dev": true,
-      "requires": {
-        "ms": "0.7.2"
-      }
-    },
-    "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-      "dev": true,
-      "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
-        }
-      }
-    },
-    "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-      "dev": true
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
-    "engine.io-client": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.1.tgz",
-      "integrity": "sha1-QVqYUrrbFPoAj6PvHjFgjbZ2EyU=",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "2.6.8",
-        "engine.io-parser": "2.1.1",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parsejson": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "2.3.1",
-        "xmlhttprequest-ssl": "1.5.3",
-        "yeast": "0.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
-    "engine.io-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.1.tgz",
-      "integrity": "sha1-4Ps/DgRi9/WLt3waUun1p+JuRmg=",
-      "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "0.0.6",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
-        "has-binary2": "1.0.2"
-      }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.2.1"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
-    "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-      "dev": true
-    },
-    "has-binary2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.2.tgz",
-      "integrity": "sha1-6D26SfC5vk0CbSc2U1DZ8D9Uvpg=",
-      "requires": {
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        }
-      }
-    },
-    "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
-    },
-    "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-      "dev": true
-    },
-    "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
-      }
-    },
-    "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
-      "dev": true
-    },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
-    },
-    "lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc=",
-      "dev": true
-    },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
-    },
-    "lolex": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-      "dev": true
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
-      "requires": {
-        "js-tokens": "3.0.1"
-      }
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
-    },
-    "mocha": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
-      "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.0",
-        "diff": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
-      }
-    },
-    "ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-      "dev": true
-    },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-      "dev": true
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
-    },
-    "object-component": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "parsejson": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
-      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
-    },
-    "parseqs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
-    },
-    "parseuri": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      }
-    },
-    "redux": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.0.tgz",
-      "integrity": "sha512-GHjaOkEQtQnnuLoYPFkRKHIqs1i1tdTlisu/xUHfk2juzCobSy4STxs4Lz5bPkc07Owb6BeGKx/r76c9IVTkOw==",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "symbol-observable": "1.0.4"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
-    },
-    "samsam": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
-      "dev": true
-    },
-    "seamless-immutable": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.2.tgz",
-      "integrity": "sha1-yHoeumdnoyRVMR12YArF7d6vu2k=",
-      "dev": true
-    },
-    "sinon": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.5.tgz",
-      "integrity": "sha1-mi/A/41SbacW8wlTqixl1RiRf2w=",
-      "dev": true,
-      "requires": {
-        "diff": "3.2.0",
-        "formatio": "1.2.0",
-        "lolex": "1.6.0",
-        "native-promise-only": "0.8.1",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.2.1",
-        "text-encoding": "0.6.4",
-        "type-detect": "4.0.3"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-          "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
-          "dev": true
-        }
-      }
-    },
-    "socket.io-client": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.3.tgz",
-      "integrity": "sha1-bK9K/5+FsZ/ZG2zhPWmttWT4hzs=",
-      "requires": {
-        "backo2": "1.0.2",
-        "base64-arraybuffer": "0.1.5",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "2.6.8",
-        "engine.io-client": "3.1.1",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "3.1.2",
-        "to-array": "0.1.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
-    "socket.io-parser": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.2.tgz",
-      "integrity": "sha1-28IoIVH8T6675Aru3Ady66YZ9/I=",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "2.6.8",
-        "has-binary2": "1.0.2",
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
-    "supports-color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-      "dev": true,
-      "requires": {
-        "has-flag": "1.0.0"
-      }
-    },
-    "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
-      "dev": true
-    },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-      "dev": true
-    },
-    "to-array": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
-    },
-    "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-      "dev": true
-    },
-    "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
-    },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-      "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "ws": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
-      "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
-      "requires": {
-        "safe-buffer": "5.0.1",
-        "ultron": "1.1.0"
-      }
-    },
-    "xmlhttprequest-ssl": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
-      "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0="
-    },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
-    }
-  }
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"after": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+		},
+		"arraybuffer.slice": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+			"integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
+		},
+		"assertion-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+			"integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+		},
+		"backo2": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base64-arraybuffer": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+		},
+		"better-assert": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+			"integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+			"requires": {
+				"callsite": "1.0.0"
+			}
+		},
+		"blob": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+			"integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+		},
+		"brace-expansion": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+		},
+		"callsite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+		},
+		"chai": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+			"requires": {
+				"assertion-error": "1.0.2",
+				"deep-eql": "0.1.3",
+				"type-detect": "1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+			"requires": {
+				"graceful-readlink": "1.0.1"
+			}
+		},
+		"component-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+			"integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+		},
+		"component-inherit": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"debug": {
+			"version": "2.6.8",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+			"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"deep-eql": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+			"requires": {
+				"type-detect": "0.1.1"
+			},
+			"dependencies": {
+				"type-detect": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+					"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+				}
+			}
+		},
+		"diff": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"engine.io-client": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.1.tgz",
+			"integrity": "sha1-QVqYUrrbFPoAj6PvHjFgjbZ2EyU=",
+			"requires": {
+				"component-emitter": "1.2.1",
+				"component-inherit": "0.0.3",
+				"debug": "2.6.8",
+				"engine.io-parser": "2.1.1",
+				"has-cors": "1.1.0",
+				"indexof": "0.0.1",
+				"parsejson": "0.0.3",
+				"parseqs": "0.0.5",
+				"parseuri": "0.0.5",
+				"ws": "2.3.1",
+				"xmlhttprequest-ssl": "1.5.3",
+				"yeast": "0.1.2"
+			}
+		},
+		"engine.io-parser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.1.tgz",
+			"integrity": "sha1-4Ps/DgRi9/WLt3waUun1p+JuRmg=",
+			"requires": {
+				"after": "0.8.2",
+				"arraybuffer.slice": "0.0.6",
+				"base64-arraybuffer": "0.1.5",
+				"blob": "0.0.4",
+				"has-binary2": "1.0.2"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"formatio": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+			"integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+			"requires": {
+				"samsam": "1.2.1"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"glob": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+			"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"graceful-readlink": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+		},
+		"growl": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
+		},
+		"has-binary2": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.2.tgz",
+			"integrity": "sha1-6D26SfC5vk0CbSc2U1DZ8D9Uvpg=",
+			"requires": {
+				"isarray": "2.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+				}
+			}
+		},
+		"has-cors": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+			"integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+		},
+		"has-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"json3": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+		},
+		"lodash": {
+			"version": "4.17.4",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+		},
+		"lodash-es": {
+			"version": "4.17.4",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+			"integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+		},
+		"lodash._baseassign": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash.keys": "3.1.2"
+			}
+		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+		},
+		"lodash._basecreate": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+			"integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+		},
+		"lodash.create": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+			"requires": {
+				"lodash._baseassign": "3.2.0",
+				"lodash._basecreate": "3.0.3",
+				"lodash._isiterateecall": "3.0.9"
+			}
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"requires": {
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
+			}
+		},
+		"lolex": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+			"integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "1.1.8"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"mocha": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+			"integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+			"requires": {
+				"browser-stdout": "1.3.0",
+				"commander": "2.9.0",
+				"debug": "2.6.8",
+				"diff": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.1",
+				"growl": "1.9.2",
+				"he": "1.1.1",
+				"json3": "3.3.2",
+				"lodash.create": "3.1.1",
+				"mkdirp": "0.5.1",
+				"supports-color": "3.1.2"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"native-promise-only": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+			"integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"object-component": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+			"integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"parsejson": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+			"integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
+			"requires": {
+				"better-assert": "1.0.2"
+			}
+		},
+		"parseqs": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+			"integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+			"requires": {
+				"better-assert": "1.0.2"
+			}
+		},
+		"parseuri": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+			"integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+			"requires": {
+				"better-assert": "1.0.2"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-to-regexp": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"requires": {
+				"isarray": "0.0.1"
+			}
+		},
+		"redux": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"requires": {
+				"lodash": "4.17.4",
+				"lodash-es": "4.17.4",
+				"loose-envify": "1.3.1",
+				"symbol-observable": "1.0.4"
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+			"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+		},
+		"safe-buffer": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+		},
+		"samsam": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+			"integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc="
+		},
+		"seamless-immutable": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.2.tgz",
+			"integrity": "sha1-yHoeumdnoyRVMR12YArF7d6vu2k="
+		},
+		"sinon": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+			"integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+			"requires": {
+				"diff": "3.2.0",
+				"formatio": "1.2.0",
+				"lolex": "1.6.0",
+				"native-promise-only": "0.8.1",
+				"path-to-regexp": "1.7.0",
+				"samsam": "1.2.1",
+				"text-encoding": "0.6.4",
+				"type-detect": "4.0.3"
+			},
+			"dependencies": {
+				"type-detect": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+					"integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo="
+				}
+			}
+		},
+		"socket.io-client": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.3.tgz",
+			"integrity": "sha1-bK9K/5+FsZ/ZG2zhPWmttWT4hzs=",
+			"requires": {
+				"backo2": "1.0.2",
+				"base64-arraybuffer": "0.1.5",
+				"component-bind": "1.0.0",
+				"component-emitter": "1.2.1",
+				"debug": "2.6.8",
+				"engine.io-client": "3.1.1",
+				"has-cors": "1.1.0",
+				"indexof": "0.0.1",
+				"object-component": "0.0.3",
+				"parseqs": "0.0.5",
+				"parseuri": "0.0.5",
+				"socket.io-parser": "3.1.2",
+				"to-array": "0.1.4"
+			}
+		},
+		"socket.io-parser": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.2.tgz",
+			"integrity": "sha1-28IoIVH8T6675Aru3Ady66YZ9/I=",
+			"requires": {
+				"component-emitter": "1.2.1",
+				"debug": "2.6.8",
+				"has-binary2": "1.0.2",
+				"isarray": "2.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+				}
+			}
+		},
+		"supports-color": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+			"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+			"requires": {
+				"has-flag": "1.0.0"
+			}
+		},
+		"symbol-observable": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+			"integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
+		},
+		"text-encoding": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+		},
+		"to-array": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+			"integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+		},
+		"type-detect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+		},
+		"ultron": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
+			"integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
+		},
+		"uuid": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"ws": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
+			"integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+			"requires": {
+				"safe-buffer": "5.0.1",
+				"ultron": "1.1.0"
+			}
+		},
+		"xmlhttprequest-ssl": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
+			"integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0="
+		},
+		"yeast": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+		}
+	}
 }

--- a/packages/resolve-redux/package.json
+++ b/packages/resolve-redux/package.json
@@ -33,6 +33,7 @@
     "uuid": "^3.0.1"
   },
   "dependencies": {
+    "isomorphic-fetch": "^2.2.1",
     "socket.io-client": "^2.0.3"
   }
 }

--- a/packages/resolve-redux/package.json
+++ b/packages/resolve-redux/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "isomorphic-fetch": "^2.2.1",
+    "regenerator-runtime": "^0.11.0",
     "socket.io-client": "^2.0.3"
   }
 }

--- a/packages/resolve-redux/src/send_command_middleware.js
+++ b/packages/resolve-redux/src/send_command_middleware.js
@@ -1,7 +1,8 @@
+import 'regenerator-runtime/runtime';
 import fetch from 'isomorphic-fetch';
 import checkRequiredFields from './warn_util';
 
-async function sendCommandDefault(command) {
+const sendCommandDefault = async (command) => {
     const response = await fetch('/api/commands', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -17,7 +18,7 @@ async function sendCommandDefault(command) {
     // eslint-disable-next-line no-console
     console.error('Send command error:', text);
     return Promise.reject(text);
-}
+};
 
 export default params => store => next => (action) => {
     const { command, aggregateId, aggregateName, payload } = action;

--- a/packages/resolve-redux/src/send_command_middleware.js
+++ b/packages/resolve-redux/src/send_command_middleware.js
@@ -20,7 +20,7 @@ const sendCommandDefault = async (command) => {
     return Promise.reject(text);
 };
 
-export default params => store => next => (action) => {
+export default (params = {}) => store => next => (action) => {
     const { command, aggregateId, aggregateName, payload } = action;
 
     const sendCommand = params.sendCommand ? params.sendCommand : sendCommandDefault;

--- a/packages/resolve-redux/src/send_command_middleware.js
+++ b/packages/resolve-redux/src/send_command_middleware.js
@@ -1,7 +1,29 @@
+import fetch from 'isomorphic-fetch';
 import checkRequiredFields from './warn_util';
+
+async function sendCommandDefault(command) {
+    const response = await fetch('/api/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify(command)
+    });
+
+    if (response.ok) {
+        return response.blob();
+    }
+
+    const text = await response.text();
+    // eslint-disable-next-line no-console
+    console.error('Send command error:', text);
+    return Promise.reject(text);
+}
 
 export default params => store => next => (action) => {
     const { command, aggregateId, aggregateName, payload } = action;
+
+    const sendCommand = params.sendCommand ? params.sendCommand : sendCommandDefault;
+
     if (
         command &&
         checkRequiredFields(
@@ -11,25 +33,22 @@ export default params => store => next => (action) => {
         ) &&
         !command.error
     ) {
-        params
-            .sendCommand(
-            {
-                type: command.type,
-                aggregateId,
-                aggregateName,
-                payload
-            },
-                store.dispatch
-            )
-            .catch((error) => {
-                store.dispatch({
-                    ...action,
-                    command: {
-                        ...action.command,
-                        error
-                    }
-                });
+        const normalizedCommand = {
+            type: command.type,
+            aggregateId,
+            aggregateName,
+            payload
+        };
+
+        sendCommand(normalizedCommand, store.dispatch).catch((error) => {
+            store.dispatch({
+                ...action,
+                command: {
+                    ...action.command,
+                    error
+                }
             });
+        });
     }
 
     return next(action);

--- a/packages/resolve-redux/src/set_subscription_middleware.js
+++ b/packages/resolve-redux/src/set_subscription_middleware.js
@@ -8,9 +8,15 @@ function createMiddleware() {
         let socketIOFailCount = 0;
         let socketIO = null;
 
+        const rootDir = typeof process !== 'undefined' &&
+            typeof process.env !== 'undefined' &&
+            process.env.ROOT_DIR
+            ? process.env.ROOT_DIR
+            : '';
+
         const initSocketIO = () => {
             socketIO = socketIOClient(window.location.origin, {
-                path: `${process.env.ROOT_DIR}/socket/`
+                path: `${rootDir}/socket/`
             });
 
             socketIO.on('event', event => store.dispatch(JSON.parse(event)));

--- a/packages/resolve-redux/src/set_subscription_middleware.js
+++ b/packages/resolve-redux/src/set_subscription_middleware.js
@@ -3,14 +3,14 @@ import socketIOClient from 'socket.io-client';
 
 const CRITICAL_LEVEL = 100;
 
-function createMiddleware({ rootDirPath }) {
+function createMiddleware() {
     return (store) => {
         let socketIOFailCount = 0;
         let socketIO = null;
 
         const initSocketIO = () => {
             socketIO = socketIOClient(window.location.origin, {
-                path: `${rootDirPath}/socket/`
+                path: `${process.env.ROOT_DIR}/socket/`
             });
 
             socketIO.on('event', event => store.dispatch(JSON.parse(event)));

--- a/packages/resolve-redux/src/set_subscription_middleware.js
+++ b/packages/resolve-redux/src/set_subscription_middleware.js
@@ -15,7 +15,7 @@ function getRootDir(params) {
         : '';
 }
 
-function createMiddleware(params) {
+function createMiddleware(params = {}) {
     return (store) => {
         let socketIOFailCount = 0;
         let socketIO = null;

--- a/packages/resolve-redux/src/set_subscription_middleware.js
+++ b/packages/resolve-redux/src/set_subscription_middleware.js
@@ -3,16 +3,24 @@ import socketIOClient from 'socket.io-client';
 
 const CRITICAL_LEVEL = 100;
 
-function createMiddleware() {
+function getRootDir(params) {
+    if (params.rootDirPath) {
+        return params.rootDirPath;
+    }
+
+    return typeof process !== 'undefined' &&
+        typeof process.env !== 'undefined' &&
+        process.env.ROOT_DIR
+        ? process.env.ROOT_DIR
+        : '';
+}
+
+function createMiddleware(params) {
     return (store) => {
         let socketIOFailCount = 0;
         let socketIO = null;
 
-        const rootDir = typeof process !== 'undefined' &&
-            typeof process.env !== 'undefined' &&
-            process.env.ROOT_DIR
-            ? process.env.ROOT_DIR
-            : '';
+        const rootDir = getRootDir(params);
 
         const initSocketIO = () => {
             socketIO = socketIOClient(window.location.origin, {


### PR DESCRIPTION
Motivation:
1. SendCommandMiddleware. In express the '/api/commands' path is set on the framework side. It is unnecessary to implement it on the client side every time. But there is still a way for customization
2. SetSubscriptionMiddleware. You always can get necessary variable from environment (as it is in other libs)