### PR TITLE
Made examples runable

### DIFF
--- a/examples/todo-two-levels/package.json
+++ b/examples/todo-two-levels/package.json
@@ -3,25 +3,30 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "react": "^16.1.1",
-    "react-dom": "^16.1.1",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "react-redux": "^5.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "redux": "^3.7.2",
-    "resolve-bus-memory": "^0.1.0",
-    "resolve-redux": "^0.1.0",
-    "resolve-scripts": "^0.1.0",
-    "resolve-storage-lite": "^0.1.0"
+    "resolve-bus-memory": "^0.2.1",
+    "resolve-redux": "^0.2.1",
+    "resolve-scripts": "0.2.1",
+    "resolve-storage-lite": "^0.2.1"
   },
   "scripts": {
-    "start": "resolve-scripts dev",
+    "build": "resolve-scripts build",
+    "dev": "resolve-scripts dev",
+    "start": "resolve-scripts start",
     "update": "resolve-scripts update",
+    "flow": "flow",
+    "test": "jest tests/unit",
     "test:functional": "cross-env NODE_ENV=tests babel-node ./tests/functional/testcafe_runner.js --presets es2015,stage-0,react"
   },
   "devDependencies": {
     "cross-env": "^5.1.1",
-    "testcafe": "^0.18.4",
+    "flow-bin": "^0.61.0",
+    "testcafe": "^0.18.5",
     "testcafe-browser-tools": "^1.4.6",
     "yargs": "^10.0.3"
   }

--- a/examples/todo-two-levels/package.json
+++ b/examples/todo-two-levels/package.json
@@ -19,13 +19,10 @@
     "dev": "resolve-scripts dev",
     "start": "resolve-scripts start",
     "update": "resolve-scripts update",
-    "flow": "flow",
-    "test": "jest tests/unit",
     "test:functional": "cross-env NODE_ENV=tests babel-node ./tests/functional/testcafe_runner.js --presets es2015,stage-0,react"
   },
   "devDependencies": {
     "cross-env": "^5.1.1",
-    "flow-bin": "^0.61.0",
     "testcafe": "^0.18.5",
     "testcafe-browser-tools": "^1.4.6",
     "yargs": "^10.0.3"

--- a/examples/todo-two-levels/tests/functional/testcafe_runner.js
+++ b/examples/todo-two-levels/tests/functional/testcafe_runner.js
@@ -24,7 +24,7 @@ getInstallations()
                 const runner = testcafe.createRunner();
                 const browser = argv.browser || Object.keys(browsers).slice(0, 1);
                 return runner
-                    .startApp('npm run start', DELAY)
+                    .startApp('npm run dev', DELAY)
                     .src(['./tests/functional/index.test.js'])
                     .browsers(browser)
                     .run();

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -17,13 +17,10 @@
     "dev": "resolve-scripts dev",
     "start": "resolve-scripts start",
     "update": "resolve-scripts update",
-    "flow": "flow",
-    "test": "jest tests/unit",
     "test:functional": "cross-env NODE_ENV=tests babel-node ./tests/functional/testcafe_runner.js --presets es2015,stage-0,react"
   },
   "devDependencies": {
     "cross-env": "^5.1.1",
-    "flow-bin": "^0.61.0",
     "testcafe": "^0.18.5",
     "testcafe-browser-tools": "^1.4.6",
     "yargs": "^10.0.3"

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -3,23 +3,28 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "react": "^16.1.1",
-    "react-dom": "^16.1.1",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
-    "resolve-bus-memory": "^0.1.0",
-    "resolve-redux": "^0.1.0",
-    "resolve-scripts": "^0.1.0",
-    "resolve-storage-lite": "^0.1.0"
+    "resolve-bus-memory": "^0.2.1",
+    "resolve-redux": "^0.2.1",
+    "resolve-scripts": "0.2.1",
+    "resolve-storage-lite": "^0.2.1"
   },
   "scripts": {
-    "start": "resolve-scripts dev",
+    "build": "resolve-scripts build",
+    "dev": "resolve-scripts dev",
+    "start": "resolve-scripts start",
     "update": "resolve-scripts update",
+    "flow": "flow",
+    "test": "jest tests/unit",
     "test:functional": "cross-env NODE_ENV=tests babel-node ./tests/functional/testcafe_runner.js --presets es2015,stage-0,react"
   },
   "devDependencies": {
     "cross-env": "^5.1.1",
-    "testcafe": "^0.18.4",
+    "flow-bin": "^0.61.0",
+    "testcafe": "^0.18.5",
     "testcafe-browser-tools": "^1.4.6",
     "yargs": "^10.0.3"
   }

--- a/examples/todo/tests/functional/testcafe_runner.js
+++ b/examples/todo/tests/functional/testcafe_runner.js
@@ -24,7 +24,7 @@ getInstallations()
                 const runner = testcafe.createRunner();
                 const browser = argv.browser || Object.keys(browsers).slice(0, 1);
                 return runner
-                    .startApp('npm run start', DELAY)
+                    .startApp('npm run dev', DELAY)
                     .src(['./tests/functional/index.test.js'])
                     .browsers(browser)
                     .run();


### PR DESCRIPTION
When I tried to start an example with the non-default `num run start`, it was complaining that the `withViewModel` is not a function of something similar.

I've updated the `package.json` of two examples with the current version generated by the `create-resolve-app`.

Now they are runable in just two intuitive commands:
```
npm i
npm run dev
```