### PR TITLE
Feature/Unexisting model entities

### DIFF
--- a/packages/core/resolve-command/src/index.js
+++ b/packages/core/resolve-command/src/index.js
@@ -118,6 +118,11 @@ export default ({ eventStore, aggregates }) => {
   return async (command, jwtToken) => {
     await verifyCommand(command)
     const aggregateName = command.aggregateName
+
+    if (!executors.hasOwnProperty(aggregateName)) {
+      throw new Error(`Aggregate ${aggregateName} does not exist`)
+    }
+
     return executors[aggregateName](command, jwtToken)
   }
 }

--- a/packages/core/resolve-scripts/src/runtime/execute_read_model_query.js
+++ b/packages/core/resolve-scripts/src/runtime/execute_read_model_query.js
@@ -6,6 +6,10 @@ const executeReadModelQuery = async ({
   resolverName,
   resolverArgs
 }) => {
+  if (!readModelQueryExecutors.hasOwnProperty(modelName)) {
+    throw new Error(`Read model ${modelName} does not exist`)
+  }
+
   return await readModelQueryExecutors[modelName].read(resolverName, {
     ...resolverArgs,
     jwtToken

--- a/packages/core/resolve-scripts/src/runtime/execute_view_model_query.js
+++ b/packages/core/resolve-scripts/src/runtime/execute_view_model_query.js
@@ -1,6 +1,10 @@
 import viewModelQueryExecutors from './view_model_query_executors'
 
 const executeViewModelQuery = async ({ modelName, aggregateIds }) => {
+  if (!viewModelQueryExecutors.hasOwnProperty(modelName)) {
+    throw new Error(`View model ${modelName} does not exist`)
+  }
+
   return await viewModelQueryExecutors[modelName].read({ aggregateIds })
 }
 


### PR DESCRIPTION
Error handling for unexisting read-models, view-models and aggregates, invoked via HTTP API. Fixes https://github.com/reimagined/resolve/issues/682