### PR TITLE
Feature/Api improvements

### DIFF
--- a/packages/core/resolve-query/src/read-model.js
+++ b/packages/core/resolve-query/src/read-model.js
@@ -182,7 +182,7 @@ const createReadModel = ({ adapter, projection, eventStore, resolvers }) => {
     getLastError: getLastError.bind(null, repository),
     read: read.bind(null, repository),
     readAndSerialize: async (...args) =>
-      JSON.stringify(await read(repository, ...args)),
+      JSON.stringify(await read(repository, ...args), null, 2),
     resolverNames: Object.keys(resolvers != null ? resolvers : {}),
     dispose: dispose.bind(null, repository)
   })

--- a/packages/core/resolve-scripts/src/core/alias/$resolve.aggregates.js
+++ b/packages/core/resolve-scripts/src/core/alias/$resolve.aggregates.js
@@ -41,9 +41,9 @@ export default ({ resolveConfig, isClient }) => {
     })
 
     if (isClient) {
-      const clientCommands =
+      const clientCommands = Object.keys(
         aggregate.commands.constructor === String
-          ? Object.keys(importBabel(resolveFile(aggregate.commands)))
+          ? importBabel(resolveFile(aggregate.commands))
           : importBabel(resolveFileOrModule(aggregate.commands.module))(
               aggregate.commands.options,
               aggregate.commands.imports != null
@@ -55,6 +55,7 @@ export default ({ resolveConfig, isClient }) => {
                   }, {})
                 : null
             )
+      )
 
       constants.push(
         `const commands_${index} = {`,

--- a/packages/core/resolve-scripts/src/defaults/view_model_serialize_state.js
+++ b/packages/core/resolve-scripts/src/defaults/view_model_serialize_state.js
@@ -1,3 +1,3 @@
-const serializeState = state => JSON.stringify(state)
+const serializeState = state => JSON.stringify(state, null, 2)
 
 export default serializeState

--- a/packages/core/resolve-scripts/src/runtime/command_handler.js
+++ b/packages/core/resolve-scripts/src/runtime/command_handler.js
@@ -1,5 +1,6 @@
 import println from './utils/println'
 import executeCommand from './command_executor'
+import extractErrorHttpCode from './utils/extract_error_http_code'
 
 const message = require('../../configs/message.json')
 
@@ -11,7 +12,8 @@ const commandHandler = async (req, res) => {
     await executeCommand({ ...req.body, jwtToken: req.jwtToken })
     res.status(200).send(message.commandSuccess)
   } catch (err) {
-    res.status(500).end(`${message.commandFail}${err.message}`)
+    const errorCode = extractErrorHttpCode(err)
+    res.status(errorCode).end(`${message.commandFail}${err.message}`)
     println.error(err)
   }
 }

--- a/packages/core/resolve-scripts/src/runtime/read_model_handler.js
+++ b/packages/core/resolve-scripts/src/runtime/read_model_handler.js
@@ -1,5 +1,6 @@
 import println from './utils/println'
 import queryExecutor from './query_executor'
+import extractErrorHttpCode from './utils/extract_error_http_code'
 
 const message = require('../../configs/message.json')
 
@@ -24,7 +25,8 @@ const readModelHandler = async (req, res) => {
 
     res.status(200).send(result)
   } catch (err) {
-    res.status(500).end(`${message.readModelFail}${err.message}`)
+    const errorCode = extractErrorHttpCode(err)
+    res.status(errorCode).end(`${message.readModelFail}${err.message}`)
     println.error(err)
   }
 }

--- a/packages/core/resolve-scripts/src/runtime/utils/extract_error_http_code.js
+++ b/packages/core/resolve-scripts/src/runtime/utils/extract_error_http_code.js
@@ -1,0 +1,22 @@
+export const httpCodeInternalServerError = 500
+export const httpMinimumCode = 100
+export const httpMaximumCode = 599
+
+const extractErrorHttpCode = error => {
+  if (!error instanceof Error || !error.hasOwnProperty('code')) {
+    return httpCodeInternalServerError
+  }
+
+  const code = error.code
+  if (
+    !Number.isInteger(code) ||
+    code < httpMinimumCode ||
+    code > httpMaximumCode
+  ) {
+    return httpCodeInternalServerError
+  }
+
+  return code
+}
+
+export default extractErrorHttpCode

--- a/packages/core/resolve-scripts/src/runtime/view_model_handler.js
+++ b/packages/core/resolve-scripts/src/runtime/view_model_handler.js
@@ -1,5 +1,6 @@
 import println from './utils/println'
 import queryExecutor from './query_executor'
+import extractErrorHttpCode from './utils/extract_error_http_code'
 
 const message = require('../../configs/message.json')
 
@@ -36,7 +37,8 @@ const viewModelHandler = async (req, res) => {
 
     res.status(200).send(serializedState)
   } catch (err) {
-    res.status(500).end(`${message.viewModelFail}${err.message}`)
+    const errorCode = extractErrorHttpCode(err)
+    res.status(errorCode).end(`${message.viewModelFail}${err.message}`)
     println.error(err)
   }
 }


### PR DESCRIPTION
Improve resolve http api: error status code translating to http codes and pretty-print read/view model query result if possible (with default serializers for view-models and always for read-models)

1) When request read-model by resolve HTTP API, result JSON is already pretty-printed, if applied. For example, HackerNews comments resolver invocation looks like
```
[
  {
    "id": "fda54ebd-b22f-492e-a5ed-154a66e65b07",
    "text": "Yes, but it’s way more powerful and integrated now.",
    "parentId": "ac039267-2171-470e-ab91-8421c7e1d93a",
    "comments": [],
    "storyId": "26347b14-3f3c-4618-b822-4a3850659cfd",
    "createdAt": 1538663328076,
    "createdBy": "6e491da9-4a75-4830-8077-6a737a4e2998",
    "createdByName": "moltar"
  },
  {
    "id": "93339ac7-7ced-40d1-968c-5e92ac8f7cc0",
    "text": "CORS is not necessarily about third parties.<p>It&#x27;s common to have app.example.org point to a CDN and api.example.org point to an API.<p>And CORS implementation is terrible. The server has to transmit validation rules for the browser to enforce (with vendor specific caching differences), rather than just enforcing access itself.<p>The reason it&#x27;s implemented this way is because of the organic evolution of web security.",
    "parentId": "6fa99d9f-4f3d-48d1-88f2-6130e7c6b71a",
    "comments": [],
    "storyId": "29ea3572-fa65-4c73-8e0a-965d8d4ccaea",
    "createdAt": 1538663328075,
    "createdBy": "59411752-bf49-403d-84a0-da2e9a9b56f3",
    "createdByName": "paulddraper"
  },
  // cut
  ]
```

2) When manual error had been thrown in command executor or read-model resolver, and error object is instance of default Error class with numeric `code` field, result HTTP result will have such code in http response

Somewhere in command executor or read-model resolver:
```
const customError = new Error('I am teapot')
customError.code = 418
throw customError
```

Result HTTP response:
```
HTTP/1.1 418 I am teapot
....
```

Fixes #680 and fixes #820