### PR TITLE
Feature/`resolve-command` execution performance improvement

### DIFF
--- a/packages/core/resolve-command/src/index.js
+++ b/packages/core/resolve-command/src/index.js
@@ -108,7 +108,9 @@ const getAggregateState = async (
       },
     );
 
-    if (event) await handler(event);
+    if (event) {
+      await handler(event);
+    }
   }
 
   return { aggregateState, aggregateVersion, lastTimestamp }


### PR DESCRIPTION
I noticed that it's common for Write Side to create Aggregates without `projection`.

In this particular case the current implementation will go through all the saved events just to gather the last `aggregateVersion`.

As a performance optimization this "walk" can be omitted and the only last saved event could be retrieved instead