### PR TITLE
Lazy create dynamo table

### DIFF
--- a/packages/adapters/storage-adapters/resolve-storage-dynamo/README.md
+++ b/packages/adapters/storage-adapters/resolve-storage-dynamo/README.md
@@ -51,14 +51,16 @@ const adapter = createAdapter({
 
 #### As Resource
 ```js
-import { create, dispose, destroy } from 'resolve-storage-dynamo'
+import { create, dispose, destroy, waitForCreate } from 'resolve-storage-dynamo'
 
-await create({ 
+const lazyResource = await create({ 
   region,
   tableName, 
   readCapacityUnits, 
   writeCapacityUnits 
 })
+
+await waitForCreate(lazyResource)
 
 await dispose({ 
   region,

--- a/packages/adapters/storage-adapters/resolve-storage-dynamo/src/index.js
+++ b/packages/adapters/storage-adapters/resolve-storage-dynamo/src/index.js
@@ -32,6 +32,9 @@ import setupAutoScalingItem from './resource/setup-auto-scaling-item'
 import resourceCreate from './resource/create'
 import resourceDispose from './resource/dispose'
 import resourceDestroy from './resource/destroy'
+import resourceWaitForCreate from './resource/wait-for-create'
+
+const resourceMap = new WeakMap()
 
 // as adapter
 const createAdapter = _createAdapter.bind(
@@ -57,7 +60,8 @@ const createAdapter = _createAdapter.bind(
     encodeEmptyStrings,
     decodeEmptyStrings,
     encodeEvent: _encodeEvent,
-    decodeEvent: _decodeEvent
+    decodeEvent: _decodeEvent,
+    resourceMap
   }
 )
 export { globalPartitionKey, rangedIndex, apiVersion }
@@ -74,14 +78,16 @@ const pool = {
   destroy: resourceDestroy,
   ApplicationAutoScaling,
   encodeEmptyStrings,
-  decodeEmptyStrings
+  decodeEmptyStrings,
+  resourceMap
 }
 
 const create = resourceCreate.bind(null, pool)
 const dispose = resourceDispose.bind(null, pool)
 const destroy = resourceDestroy.bind(null, pool)
+const waitForCreate = resourceWaitForCreate.bind(null, pool)
 
-export { create, dispose, destroy, decodeEmptyStrings }
+export { create, waitForCreate, dispose, destroy, decodeEmptyStrings }
 
 const encodeEvent = _encodeEvent.bind(null, pool)
 const decodeEvent = _decodeEvent.bind(null, pool)

--- a/packages/adapters/storage-adapters/resolve-storage-dynamo/src/init.js
+++ b/packages/adapters/storage-adapters/resolve-storage-dynamo/src/init.js
@@ -6,7 +6,8 @@ const init = async ({
   readCapacityUnits,
   writeCapacityUnits,
   database,
-  checkTableExists
+  checkTableExists,
+  lazyWaitForCreate = false
 }) => {
   if (await checkTableExists(database, tableName)) {
     return
@@ -86,7 +87,15 @@ const init = async ({
     })
     .promise()
 
-  while (!(await checkTableExists(database, tableName))) {}
+  const waitForCreate = async () => {
+    while (!(await checkTableExists(database, tableName))) {}
+  }
+
+  if (lazyWaitForCreate) {
+    return waitForCreate
+  } else {
+    await waitForCreate()
+  }
 }
 
 export default init

--- a/packages/adapters/storage-adapters/resolve-storage-dynamo/src/resource/create.js
+++ b/packages/adapters/storage-adapters/resolve-storage-dynamo/src/resource/create.js
@@ -1,15 +1,20 @@
 const create = async (pool, options) => {
-  const { createAdapter, setupAutoScaling } = pool
+  const { createAdapter, setupAutoScaling, resourceMap } = pool
 
   const dynamoAdapter = createAdapter({
     ...options,
-    skipInit: true
+    skipInit: true,
+    lazyWaitForCreate: true
   })
-  await dynamoAdapter.init()
+
+  const lazyResource = Object.create(null)
+  resourceMap.set(lazyResource, await dynamoAdapter.init())
 
   if (pool.billingMode === 'PROVISIONED') {
     await setupAutoScaling(pool, options)
   }
+
+  return lazyResource
 }
 
 export default create

--- a/packages/adapters/storage-adapters/resolve-storage-dynamo/src/resource/wait-for-create.js
+++ b/packages/adapters/storage-adapters/resolve-storage-dynamo/src/resource/wait-for-create.js
@@ -1,0 +1,11 @@
+const waitForCreate = (pool, lazyResource) => {
+  const { resourceMap } = pool
+
+  if (!resourceMap.has(lazyResource)) {
+    throw new Error('Invalid arguments')
+  }
+
+  return resourceMap.get(lazyResource)()
+}
+
+export default waitForCreate


### PR DESCRIPTION
```js
import { create, dispose, destroy, waitForCreate } from 'resolve-storage-dynamo'

const lazyResource = await create({ 
  region,
  tableName, 
  readCapacityUnits, 
  writeCapacityUnits 
})

await waitForCreate(lazyResource)
```