### PR TITLE
Fix tests failing due to timezone

### DIFF
--- a/examples/cli-uploader/jest.config.js
+++ b/examples/cli-uploader/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/hacker-news/jest.config.js
+++ b/examples/hacker-news/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   setupFiles: ['raf/polyfill', '<rootDir>/test/unit/jest-setup.js'],

--- a/examples/hello-world-typescript/jest.config.ts
+++ b/examples/hello-world-typescript/jest.config.ts
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/hello-world/jest.config.js
+++ b/examples/hello-world/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/image-gallery/jest.config.js
+++ b/examples/image-gallery/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/shopping-list-advanced/native/jest.config.js
+++ b/examples/shopping-list-advanced/native/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 const path = require('path')
 
 module.exports = {

--- a/examples/shopping-list-advanced/ui/jest.config.native.js
+++ b/examples/shopping-list-advanced/ui/jest.config.native.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 const path = require('path')
 
 module.exports = {

--- a/examples/shopping-list-advanced/ui/jest.config.web.js
+++ b/examples/shopping-list-advanced/ui/jest.config.web.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 const path = require('path')
 
 module.exports = {

--- a/examples/shopping-list-advanced/web/jest.config.js
+++ b/examples/shopping-list-advanced/web/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 const path = require('path')
 
 module.exports = {

--- a/examples/shopping-list-tutorial/lesson-2/jest.config.js
+++ b/examples/shopping-list-tutorial/lesson-2/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/shopping-list-tutorial/lesson-3/jest.config.js
+++ b/examples/shopping-list-tutorial/lesson-3/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/shopping-list-tutorial/lesson-4/jest.config.js
+++ b/examples/shopping-list-tutorial/lesson-4/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/shopping-list-tutorial/lesson-5/jest.config.js
+++ b/examples/shopping-list-tutorial/lesson-5/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/shopping-list-tutorial/lesson-6/jest.config.js
+++ b/examples/shopping-list-tutorial/lesson-6/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/shopping-list-tutorial/lesson-7/jest.config.js
+++ b/examples/shopping-list-tutorial/lesson-7/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/shopping-list-with-hooks/jest.config.js
+++ b/examples/shopping-list-with-hooks/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/shopping-list/jest.config.js
+++ b/examples/shopping-list/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/with-angular/jest.config.js
+++ b/examples/with-angular/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/with-postcss/jest.config.js
+++ b/examples/with-postcss/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/with-styled-components/jest.config.js
+++ b/examples/with-styled-components/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/examples/with-vue/jest.config.js
+++ b/examples/with-vue/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 const path = require('path')
 
 module.exports = {

--- a/packages/core/resolve-client/jest.config.js
+++ b/packages/core/resolve-client/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {

--- a/packages/core/resolve-react-hooks/jest.config.js
+++ b/packages/core/resolve-react-hooks/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'Europe/Moscow'
+
 module.exports = {
   testEnvironment: 'node',
   transform: {


### PR DESCRIPTION
Fixes #1371 by defining `process.env.TZ = 'Europe/Moscow'` inside each Jest config file.