### PR TITLE
Hotfix/Snapshot methods (load, save, and drop) not exposed on PostgreSQL eventstore adapter

### DIFF
--- a/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/src/index.ts
+++ b/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/src/index.ts
@@ -14,6 +14,9 @@ import coercer from './js/coercer'
 import escapeId from './js/escape-id'
 import escape from './js/escape'
 import shapeEvent from './js/shape-event'
+import loadSnapshot from './js/load-snapshot'
+import saveSnapshot from './js/save-snapshot'
+import dropSnapshot from './js/drop-snapshot'
 
 import connect from './connect'
 import init from './init'
@@ -40,7 +43,10 @@ const createAdapter = _createAdapter.bind(null, {
   injectEvent,
   coercer,
   shapeEvent,
-  getSecretsManager
+  getSecretsManager,
+  loadSnapshot,
+  saveSnapshot,
+  dropSnapshot
 })
 
 export default createAdapter


### PR DESCRIPTION
This fixes issue #1433 as mentioned in this request's title.