### PR TITLE
Hotfix/Snapshot methods (load, save, and drop) not exposed on PostgreSQL eventstore adapter

### DIFF
--- a/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/src/index.ts
+++ b/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/src/index.ts
@@ -14,6 +14,9 @@ import coercer from './js/coercer'
 import escapeId from './js/escape-id'
 import escape from './js/escape'
 import shapeEvent from './js/shape-event'
+import loadSnapshot from './js/load-snapshot'
+import saveSnapshot from './js/save-snapshot'
+import dropSnapshot from './js/drop-snapshot'
 
 import connect from './connect'
 import init from './init'
@@ -40,7 +43,10 @@ const createAdapter = _createAdapter.bind(null, {
   injectEvent,
   coercer,
   shapeEvent,
-  getSecretsManager
+  getSecretsManager,
+  loadSnapshot,
+  saveSnapshot,
+  dropSnapshot
 })
 
 export default createAdapter

--- a/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/test/index.unit.test.ts
+++ b/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/test/index.unit.test.ts
@@ -26,7 +26,6 @@ import loadSnapshot from '../src/js/load-snapshot'
 import saveSnapshot from '../src/js/save-snapshot'
 import dropSnapshot from '../src/js/drop-snapshot'
 
-
 import createAdapter from '../src/index'
 
 jest.mock('../src/js/load-events-by-cursor', () => jest.fn())

--- a/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/test/index.unit.test.ts
+++ b/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/test/index.unit.test.ts
@@ -22,6 +22,10 @@ import init from '../src/init'
 import drop from '../src/drop'
 import dispose from '../src/dispose'
 import getSecretsManager from '../src/secrets-manager'
+import loadSnapshot from '../src/js/load-snapshot'
+import saveSnapshot from '../src/js/save-snapshot'
+import dropSnapshot from '../src/js/drop-snapshot'
+
 
 import createAdapter from '../src/index'
 
@@ -42,6 +46,9 @@ jest.mock('../src/init', () => jest.fn())
 jest.mock('../src/drop', () => jest.fn())
 jest.mock('../src/dispose', () => jest.fn())
 jest.mock('../src/secrets-manager', () => jest.fn())
+jest.mock('../src/js/load-snapshot', () => jest.fn())
+jest.mock('../src/js/save-snapshot', () => jest.fn())
+jest.mock('../src/js/drop-snapshot', () => jest.fn())
 
 const mGenericCreateAdapter = mocked(genericCreateAdapter)
 
@@ -66,6 +73,9 @@ test('generic createAdapter invoked', () => {
     injectEvent,
     coercer,
     shapeEvent,
-    getSecretsManager
+    getSecretsManager,
+    loadSnapshot,
+    saveSnapshot,
+    dropSnapshot
   })
 })


### PR DESCRIPTION
This fixes issue #1433 as mentioned in this request's title.