### PR TITLE
Fixed issue with loadEvents with a finishTime

### DIFF
--- a/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/src/js/load-events-by-timestamp.js
+++ b/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/src/js/load-events-by-timestamp.js
@@ -23,10 +23,10 @@ const loadEventsByTimestamp = async (
     queryConditions.push(`"aggregateId" IN (${aggregateIds.map(injectString)})`)
   }
   if (startTime != null) {
-    queryConditions.push(`"startTime" >= ${injectNumber(startTime)}`)
+    queryConditions.push(`"timestamp" >= ${injectNumber(startTime)}`)
   }
   if (finishTime != null) {
-    queryConditions.push(`"finishTime" <= ${injectNumber(finishTime)}`)
+    queryConditions.push(`"timestamp" <= ${injectNumber(finishTime)}`)
   }
 
   const resultQueryCondition =

--- a/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/test/statement.unit.test.ts
+++ b/packages/adapters/eventstore-adapters/resolve-eventstore-postgresql/test/statement.unit.test.ts
@@ -1,0 +1,44 @@
+import loadEventsByTimestamp from '../src/js/load-events-by-timestamp'
+
+jest.mock('../src/js/get-log')
+jest.mock('../src/js/drop', () => jest.fn())
+
+type ArgType = {
+  escapeId: any
+  escape: any
+  eventsTableName: any
+  databaseName: any
+  executeStatement: any
+  shapeEvent: any
+}
+
+let arg1: ArgType
+
+beforeEach(() => {
+  arg1 = {
+    escape: jest.fn((v) => v),
+    eventsTableName: 'events-table-name',
+    databaseName: 'database',
+    executeStatement: jest.fn(() => []),
+    escapeId: jest.fn((v) => `${v}`),
+    shapeEvent: jest.fn(),
+  }
+})
+
+test('loadEventsByTimestamp has correct filters', async () => {
+  const filter = {
+    eventTypes: ['test'],
+    aggregateIds: ['test-1'],
+    startTime: Date.now(),
+    finishTime: Date.now(),
+    limit: 1,
+  }
+  await loadEventsByTimestamp(arg1, filter)
+
+  // prettier-ignore
+  expect(arg1.executeStatement)
+    .toHaveBeenCalledWith(`SELECT * FROM ${arg1.databaseName}.${arg1.eventsTableName}
+WHERE "type" IN (${filter.eventTypes.join(',')}) AND "aggregateId" IN (${filter.aggregateIds.join(',')}) AND "timestamp" >= ${filter.startTime} AND "timestamp" <= ${filter.finishTime}
+ORDER BY "timestamp" ASC, "threadCounter" ASC, "threadId" ASC
+LIMIT ${filter.limit}`)
+})


### PR DESCRIPTION
`loadEventsByTimestamp` in `resolve-eventstore-postgresql` was not properly evaluating `startTime` and `finishTime` parameters against the `timestamp` field.  This has been fixed and a test written.