### PR TITLE
Optimize loadevents for postgresql eventstore adapter

### DIFF
--- a/packages/runtime/adapters/eventstore-adapters/eventstore-postgresql/src/create-load-query.ts
+++ b/packages/runtime/adapters/eventstore-adapters/eventstore-postgresql/src/create-load-query.ts
@@ -15,7 +15,7 @@ const createLoadQuery = (
   const injectString = (value: any): string => `${escape(value)}`
   const injectNumber = (value: any): string => `${+value}`
 
-  const queryConditions: string[] = []
+  const queryConditions: string[] = ['1 = 1']
   if (eventTypes != null) {
     if (eventTypes.length === 0) {
       return null
@@ -30,39 +30,43 @@ const createLoadQuery = (
   }
 
   const resultQueryCondition = queryConditions.join(' AND ')
-  const resultVectorConditions = `${vectorConditions
-    .map(
-      (threadCounter, threadId) =>
-        `"threadId" = ${injectNumber(
-          threadId
-        )} AND "threadCounter" >= ${threadCounter}::${INT8_SQL_TYPE} `
-    )
-    .join(' OR ')}`
-
-  const resultTimestampConditions = vectorConditions
-    .map(
-      (threadCounter, threadId) =>
-        `"threadId" = ${injectNumber(
-          threadId
-        )} AND "threadCounter" = ${threadCounter}::${INT8_SQL_TYPE}`
-    )
-    .join(' OR ')
 
   const databaseNameAsId: string = escapeId(databaseName)
   const eventsTableAsId: string = escapeId(eventsTableName)
 
-  return [
-    `WITH "minimalTimestamp" AS (
-        SELECT MIN("timestamp") AS "value" FROM ${databaseNameAsId}.${eventsTableAsId}
-        WHERE ${resultTimestampConditions}
-      )`,
-    `SELECT * FROM ${databaseNameAsId}.${eventsTableAsId}`,
-    `WHERE "timestamp" >= (SELECT "minimalTimestamp"."value" FROM "minimalTimestamp") AND (${resultVectorConditions}) ${
-      resultQueryCondition.length > 0 ? `AND (${resultQueryCondition})` : ''
-    }`,
-    `ORDER BY "timestamp" ASC, "threadCounter" ASC, "threadId" ASC`,
-    limit !== undefined ? `LIMIT ${+limit}` : '',
-  ].join('\n')
+  if (limit !== undefined) {
+    return [
+      `SELECT "unitedEvents".* FROM (
+        ${vectorConditions
+          .map(
+            (threadCounter, threadId) =>
+              `(${[
+                `SELECT * FROM ${databaseNameAsId}.${eventsTableAsId}`,
+                `WHERE (${resultQueryCondition}) AND "threadId" = ${threadId} AND "threadCounter" >= ${threadCounter}::${INT8_SQL_TYPE}`,
+                `LIMIT ${limit}`,
+              ].join(' ')})`
+          )
+          .join(' UNION ALL \n')}
+        ) "unitedEvents"`,
+      `ORDER BY "unitedEvents"."timestamp" ASC, "unitedEvents"."threadCounter" ASC, "unitedEvents"."threadId" ASC`,
+      `LIMIT ${+limit}`,
+    ].join('\n')
+  } else {
+    const resultVectorConditions = `${vectorConditions
+      .map(
+        (threadCounter, threadId) =>
+          `"threadId" = ${injectNumber(
+            threadId
+          )} AND "threadCounter" >= ${threadCounter}::${INT8_SQL_TYPE} `
+      )
+      .join(' OR ')}`
+
+    return [
+      `SELECT * FROM ${databaseNameAsId}.${eventsTableAsId}`,
+      `WHERE (${resultVectorConditions}) AND (${resultQueryCondition})`,
+      `ORDER BY "timestamp" ASC, "threadCounter" ASC, "threadId" ASC`,
+    ].join('\n')
+  }
 }
 
 export default createLoadQuery


### PR DESCRIPTION
With these changes RDS replies in 8-22 seconds when loading 1000 events from the database with 11M events since the starting cursor.
Before these changes RDS couldn't even reply in time (45 seconds).