### PR TITLE
Fix issue with event.timestamp and +/-1 in @resolve-js/testing-tools

### DIFF
--- a/packages/tools/testing-tools/src/runtime/get-event-store.ts
+++ b/packages/tools/testing-tools/src/runtime/get-event-store.ts
@@ -70,9 +70,9 @@ export const getEventStore = async (
         const event = events[timestampIndex]
 
         event.timestamp =
-          (eventByAggregateIdVersion.get(
+          eventByAggregateIdVersion.get(
             `${event.aggregateId}:${event.aggregateVersion}`
-          )?.timestamp ?? timestampIndex) + 1
+          )?.timestamp ?? timestampIndex + 1
       }
 
       return {

--- a/packages/tools/testing-tools/test/__snapshots__/read-model.test.ts.snap
+++ b/packages/tools/testing-tools/test/__snapshots__/read-model.test.ts.snap
@@ -20,15 +20,15 @@ Array [
 exports[`givenEvents tests should match snapshot with specified timestamp 1`] = `
 Array [
   Object {
-    "timestamp": 11,
+    "timestamp": 10,
     "value": "test-1",
   },
   Object {
-    "timestamp": 21,
+    "timestamp": 20,
     "value": "test-2",
   },
   Object {
-    "timestamp": 31,
+    "timestamp": 30,
     "value": "test-3",
   },
 ]

--- a/packages/tools/testing-tools/test/read-model.test.ts
+++ b/packages/tools/testing-tools/test/read-model.test.ts
@@ -243,6 +243,20 @@ describe('givenEvents tests', () => {
       .readModel(readModel)
       .query('all', {})
 
+    expect(result?.items).toEqual([
+      {
+        value: 'test-1',
+        timestamp: 10,
+      },
+      {
+        value: 'test-2',
+        timestamp: 20,
+      },
+      {
+        value: 'test-3',
+        timestamp: 30,
+      },
+    ])
     expect(result?.items).toMatchSnapshot()
   })
 


### PR DESCRIPTION
Regression test: https://github.com/reimagined/resolve/runs/4815461917?check_suite_focus=true#step:13:1631