### PR TITLE
Decrease custom read model connections

### DIFF
--- a/packages/runtime/runtimes/runtime-base/src/bootstrap-one.ts
+++ b/packages/runtime/runtimes/runtime-base/src/bootstrap-one.ts
@@ -29,20 +29,7 @@ export const bootstrapOne = async ({
       await ensureQueue(name)
     } catch (err) {
       errors.push(err)
-    }
-
-    try {
-      log.debug(`ensuring event subscriber`)
-      await eventstoreAdapter.ensureEventSubscriber({
-        applicationName,
-        eventSubscriber: name,
-        status: null,
-        destination,
-      })
-    } catch (err) {
-      log.error(err)
-      errors.push(err)
-    }
+    }    
 
     try {
       log.debug(`subscribing`)

--- a/packages/runtime/runtimes/runtime-base/src/bootstrap-one.ts
+++ b/packages/runtime/runtimes/runtime-base/src/bootstrap-one.ts
@@ -29,13 +29,14 @@ export const bootstrapOne = async ({
       await ensureQueue(name)
     } catch (err) {
       errors.push(err)
-    }    
+    }
 
     try {
       log.debug(`subscribing`)
       await eventSubscriber.subscribe({
         eventSubscriber: name,
         subscriptionOptions: { eventTypes },
+        destination,
       })
 
       if (upstream || forceResume) {

--- a/packages/runtime/runtimes/runtime-base/src/query/wrap-read-model.ts
+++ b/packages/runtime/runtimes/runtime-base/src/query/wrap-read-model.ts
@@ -177,8 +177,8 @@ export const subscribeImpl = async (
     subscriptionOptions: {
       eventTypes: Array<string> | null
       aggregateIds: Array<string> | null
-    },
-    destination: string,
+    }
+    destination: string
   }
 ) => {
   const entry = (
@@ -212,7 +212,7 @@ export const subscribeImpl = async (
       },
       updateOnly: true,
     })
-  }  
+  }
 }
 
 export const resubscribeImpl = async (
@@ -222,8 +222,8 @@ export const resubscribeImpl = async (
     subscriptionOptions: {
       eventTypes: Array<string> | null
       aggregateIds: Array<string> | null
-    },
-    destination: string,
+    }
+    destination: string
   }
 ) => {
   await pool.eventstoreAdapter.ensureEventSubscriber({
@@ -562,8 +562,8 @@ export const customReadModelMethods: Record<
       subscriptionOptions: {
         eventTypes: Array<string> | null
         aggregateIds: Array<string> | null
-      },
-      destination: string,
+      }
+      destination: string
     }
   ) => {
     await subscribeImpl(pool, readModelName, parameters)
@@ -578,8 +578,8 @@ export const customReadModelMethods: Record<
       subscriptionOptions: {
         eventTypes: Array<string> | null
         aggregateIds: Array<string> | null
-      },
-      destination: string,
+      }
+      destination: string
     }
   ) => {
     await resubscribeImpl(pool, readModelName, parameters)

--- a/packages/runtime/runtimes/runtime-base/src/shutdown-one.ts
+++ b/packages/runtime/runtimes/runtime-base/src/shutdown-one.ts
@@ -31,15 +31,6 @@ export const shutdownOne = async ({
     }
 
     try {
-      await eventStoreAdapter.removeEventSubscriber({
-        applicationName: eventSubscriberScope,
-        eventSubscriber: name,
-      })
-    } catch (err) {
-      errors.push(err)
-    }
-
-    try {
       await deleteQueue(name)
     } catch (err) {
       errors.push(err)


### PR DESCRIPTION
Change elastic-search-connector.ts: 
import { Client, ClientOptions } from '@elastic/elasticsearch'
let counter = 0
const connect = (options: ClientOptions) => async () => {
  counter++
  const r = options.node ? new Client(options) : null
  console.log('Counter: ', counter)
  return r
}
const drop = async (client: Client) => {
  if (client) await client.indices.delete({ index: 'primary' })
}

const createConnector = (options: ClientOptions) => ({
  connect: connect(options),
  drop,
})

export default createConnector

Calls on current dev branch:
<img width="218" alt="before" src="https://user-images.githubusercontent.com/45823643/149939591-e4ae50db-6418-482a-82ee-0946fd79cd29.png">

Calls after fix:
<img width="350" alt="after" src="https://user-images.githubusercontent.com/45823643/149939742-17939029-dcf6-4467-831e-78e4498c0035.png">