### PR TITLE
Hotfix paths and names in the examples readme page

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,8 +7,8 @@ The following example projects are available:
 | Example Name                                                                                                                   | Description                                                                                             |
 | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
 | [shopping-list](https://github.com/reimagined/resolve/tree/master/examples/ts/shopping-list)                                   | Demonstrates how to work with Read Models and View Models.                                              |
-| [shopping-list-with-hooks](https://github.com/reimagined/resolve/tree/master/examples/ts/shopping-list-with-hooks)             | Demonstrates how to use the **@resolve-js/react-hooks** client library tp communicate with the backend. |
-| [shopping-list-with-redux-hooks](https://github.com/reimagined/resolve/tree/master/examples/ts/shopping-list-with-redux-hooks) | Demonstrates how to use the **@resolve-js/redux** library's hooks to communicate with the backend.      |
+| [shopping-list-redux](https://github.com/reimagined/resolve/tree/master/examples/ts/shopping-list-redux)             | Demonstrates how to use the **@resolve-js/react-hooks** client library to communicate with the backend. |
+| [shopping-list-redux-hoc](https://github.com/reimagined/resolve/tree/master/examples/ts/shopping-list-redux-hoc) | Demonstrates how to use the **@resolve-js/redux** library's hooks to communicate with the backend.      |
 | [hacker-news](https://github.com/reimagined/resolve/tree/master/examples/ts/hacker-news)                                       | A clone of the [HackerNews](https://news.ycombinator.com/) application implemented using reSolve.       |
 | [personal-data](https://github.com/reimagined/resolve/tree/master/examples/ts/personal-data)                                   | Demonstrates how to store encrypted personal data.                                                      |
 


### PR DESCRIPTION

Fix paths and names in the examples readme page.