### PR TITLE
Fix event subscriber table not updating busy status after initial events iteration

### DIFF
--- a/packages/runtime/runtimes/runtime-base/src/custom-read-model.ts
+++ b/packages/runtime/runtimes/runtime-base/src/custom-read-model.ts
@@ -140,6 +140,17 @@ const customReadModelMethods = {
           throw summaryError
         }
       } else if (events.length === 0) {
+        // Update event subscriber status to "not busy",
+        // otherwise no events will pass the busy check above
+        await eventstoreAdapter.ensureEventSubscriber({
+          applicationName,
+          eventSubscriber,
+          status: { ...status,
+            busy: false
+          },
+          updateOnly: true
+        });
+
         return {
           type: 'build-direct-invoke',
           payload: {


### PR DESCRIPTION
This PR proposes a fix for this issue: https://github.com/reimagined/resolve/issues/2294.

The bug as defined in the above issue is summarized as: Creating a new application with a custom-read-model-connector results in the custom read model projection handler not being called. The event subscriber table keeps the current state of an event subscriber with the `busy` column. In the problematic case on app startup, an empty array of events are retrieved for the custom read model. This results in running code where the `busy` state is never updated to false. Since there is a check for `busy` before calling event handlers, the check always returns `busy` is true and the event handling is exited early.

The fix in this PR updates the event subscriber table and `busy` to false after an empty array of events is processed. Before this fix, execution ends in an empty if block with the comment `TODO???`. It's also possible the real problem is the event handler processing function `custom-read-model.ts` `build` function should never be called.

With this fix, custom read model projection handlers are called like normal.